### PR TITLE
require node 16 as adapter-core 3.x.x is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/Grizzelbee/ioBroker.wireguard.git"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "@iobroker/plugin-sentry": "^1.2.1",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail during installation at node 14 as npm 6 fails to install peerDependencies. So this adapter requires node 16 or newer