### PR TITLE
removed @iobroker/plugin-sentry dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Basically there are three ways to execute the command:
 
 ## Changelog
 ### **WORK IN PROGRESS**
+* (@foxriver76) Removed `@iobroker/plugin-sentry` dependency
 
 ### 1.6.4 (2024-05-08)
 * (grizzelbee) Upd: Dependencies got updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.1.4",
-        "@iobroker/plugin-sentry": "^1.2.1",
         "ssh2": "^1.15.0"
       },
       "devDependencies": {
@@ -2747,22 +2746,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/@iobroker/plugin-base": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@iobroker/plugin-base/-/plugin-base-1.2.1.tgz",
-      "integrity": "sha512-G3liVMb9PIY9+17ErcUxmSdxqBL/cIWxt69rq+6abnprGZP+psLh6isgQn5Dqifgis6us6FyRy1a/t4LP+Lzlg=="
-    },
-    "node_modules/@iobroker/plugin-sentry": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@iobroker/plugin-sentry/-/plugin-sentry-1.2.1.tgz",
-      "integrity": "sha512-lZIcgjiNVOXp9nupNNagGOEynR/bYWg63WyPIN4vEhtQvqCEGcFjWulSSgZ6HBWLR8uZRQvN8su7MC8VOUvF3w==",
-      "dependencies": {
-        "@iobroker/plugin-base": "^1.2.1",
-        "@sentry/integrations": "^7.55.2",
-        "@sentry/node": "^7.55.2",
-        "source-map-support": "^0.5.21"
-      }
-    },
     "node_modules/@iobroker/testing": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@iobroker/testing/-/testing-4.1.3.tgz",
@@ -3491,78 +3474,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "dev": true
-    },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.108.0.tgz",
-      "integrity": "sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==",
-      "dependencies": {
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.108.0.tgz",
-      "integrity": "sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==",
-      "dependencies": {
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.108.0.tgz",
-      "integrity": "sha512-b/WbK1f3x2rQ4aJJSA4VSwpBXrXFm1Nzrca3Y9qW0MI1wjZEYsDDrh9m6ulLdVBl4YDc2VqYp1COwU/NjuHlog==",
-      "dependencies": {
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/node": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.108.0.tgz",
-      "integrity": "sha512-pMxc9txnDDkU4Z8k2Uw/DPSLPehNtWV3mjJ3+my0AMORGYrXLkJI93tddlE5z/7k+GEJdj1HsOLgxUN0OU+HGA==",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.108.0",
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.108.0.tgz",
-      "integrity": "sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.108.0.tgz",
-      "integrity": "sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==",
-      "dependencies": {
-        "@sentry/types": "7.108.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -4842,7 +4753,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -8620,11 +8532,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -9768,14 +9675,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/linkify-it": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
@@ -9783,14 +9682,6 @@
       "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "dependencies": {
-        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -13656,6 +13547,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13678,6 +13570,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.1.4",
-    "@iobroker/plugin-sentry": "^1.2.1",
     "ssh2": "^1.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The dependency should only be used by the js-controller, no need to specify it as dependency in adapters. 
With js-controller v7 the sentry plugin in version 2 is used and specifying another version will break the resolution of the plugin for users.

Please create a new release after merging.